### PR TITLE
Allow targeting a node and honor LV dashboard switcher

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## NEXT
 
-* Allow targeting a node to run on and honor dashboard node switcher
+* Allow targeting a node to run on, and honor dashboard node switcher
 ## 0.3.0
 
 * Upgrade eFlambe to 0.2.3 to resolve graph truncation and :not_mocked error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## NEXT
+
+* Allow targeting a node to run on and honor dashboard node switcher
 ## 0.3.0
 
 * Upgrade eFlambe to 0.2.3 to resolve graph truncation and :not_mocked error

--- a/lib/flame_on/capture.ex
+++ b/lib/flame_on/capture.ex
@@ -2,24 +2,46 @@ defmodule FlameOn.Capture do
   @output_directory "flame_on_output_delete_me"
   @check_interval 500
 
-  def capture(module, function, arity, pid, id, timeout \\ 15_000) do
+  def capture(module, function, arity, opts) do
+    target_node = Keyword.get(opts, :target_node, Node.self())
+
+    Node.spawn(target_node, __MODULE__, :__local_capture__, [
+      self(),
+      module,
+      function,
+      arity,
+      opts
+    ])
+
+    receive do
+      {:__local_capture_start__, :success} -> :ok
+      {:__local_capture_start__, :error, error} -> raise "Node.spawn_link failed with error: #{inspect(error)}"
+    after
+      5_000 -> raise "__local_capture__ failed due to timeout"
+    end
+  end
+
+  def __local_capture__(from, module, function, arity, opts) do
+    reply_pid = Keyword.get(opts, :reply_pid, self())
+    reply_id = Keyword.fetch!(opts, :reply_id)
+    timeout = Keyword.get(opts, :timeout, 15_000)
+
     File.rm_rf!(@output_directory)
     File.mkdir!(@output_directory)
 
-    :eflambe.capture({module, function, arity}, 1, output_directory: @output_directory)
-    watch_output_directory(pid, id, timeout)
+    :ok = :eflambe.capture({module, function, arity}, 1, output_directory: @output_directory)
+    send(from, {:__local_capture_start__, :success})
+    watch_output_directory(reply_pid, reply_id, timeout)
+  rescue
+    e -> send(from, {:__local_capture_start__, :error, e})
   end
 
-  def watch_output_directory(pid, id, timeout) do
-    spawn(fn -> watch_output_directory_loop(pid, id, timeout) end)
-  end
-
-  defp watch_output_directory_loop(pid, id, timeout, count \\ 0) do
+  defp watch_output_directory(pid, id, timeout, count \\ 0) do
     case File.ls!(@output_directory) do
       [] ->
         if count * @check_interval <= timeout do
           :timer.sleep(@check_interval)
-          watch_output_directory_loop(pid, id, timeout, count + 1)
+          watch_output_directory(pid, id, timeout, count + 1)
         else
           Phoenix.LiveView.send_update(pid, FlameOn.Component, id: id, flame_on_timed_out: true)
         end

--- a/lib/flame_on/component.ex
+++ b/lib/flame_on/component.ex
@@ -106,6 +106,7 @@ defmodule FlameOn.Component do
         |> assign(:view_block_path, [])
         |> assign(:capture_timed_out?, false)
         |> assign(:id, assigns.id)
+        |> assign(:target_node, Map.get(assigns, :node, Node.self()))
       else
         socket
       end
@@ -124,12 +125,15 @@ defmodule FlameOn.Component do
           values.module,
           values.function,
           values.arity,
-          self(),
-          socket.assigns.id,
-          values.timeout
+          reply_pid: self(),
+          reply_id: socket.assigns.id,
+          timeout: values.timeout,
+          target_node: socket.assigns.target_node
         )
 
-        assign(socket, :capturing?, true)
+        socket
+        |> assign(:capturing?, true)
+        |> assign(:capture_timed_out?, false)
       else
         socket
       end
@@ -183,5 +187,13 @@ defmodule FlameOn.Component do
       arity: arity,
       timeout: timeout
     }
+  end
+
+  defp target_or_local_node(node) do
+    if node == Node.self() do
+      "local node"
+    else
+      "node #{node}"
+    end
   end
 end

--- a/lib/flame_on/component.html.heex
+++ b/lib/flame_on/component.html.heex
@@ -130,7 +130,7 @@
     
     <%= submit "Flame On!", class: "submit", disabled: !@capture_changeset.valid? %>
   </.form><br>
-  <%= if @capturing? do %>Capturing...<br><% end %>
+  <%= if @capturing? do %>Capturing on <%= target_or_local_node(@target_node) %>...<br><% end %>
   <%= if @capture_timed_out? do %>Capture Timed Out<br><% end %>
 
   <%= if not is_nil(@viewing_block) do %>

--- a/lib/flame_on/dashboard_page.ex
+++ b/lib/flame_on/dashboard_page.ex
@@ -9,7 +9,7 @@ defmodule FlameOn.DashboardPage do
   end
 
   @impl PageBuilder
-  def render_page(_assigns) do
-    {FlameOn.Component, %{id: :flame_on_component}}
+  def render_page(%{page: %{node: node}}) do
+    {FlameOn.Component, %{id: :flame_on_component, node: node}}
   end
 end


### PR DESCRIPTION
Allow a node to be specified to run the capture on. Honor node selected in LV Dashboard node selector.