### PR TITLE
Add commas to integer durations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## NEXT
 
 * Allow targeting a node to run on, and honor dashboard node switcher
+* Add commas to integers in tooltips for readability
+
 ## 0.3.0
 
 * Upgrade eFlambe to 0.2.3 to resolve graph truncation and :not_mocked error

--- a/lib/flame_on/svg.ex
+++ b/lib/flame_on/svg.ex
@@ -46,7 +46,7 @@ defmodule FlameOn.SVG do
     <svg width={Enum.max([trunc(@block.duration * @duration_ratio), 1])} height={@block_height} x={(@block.absolute_start - @top_block.absolute_start) * @duration_ratio} y={(@block.level - @top_block.level) * @block_height} phx-click="view_block" phx-target={@parent} phx-value-id={@block.id}>
       <rect width="100%" height="100%" style={"fill: #{color};"}></rect>
       <text x={@block_height/4} y={@block_height * 0.5}><%=@block.function %></text>
-      <title><%= @block.duration %>&micro;s (<%= trunc((@block.duration * 100) / @top_block.duration) %>%) <%=@block.function %></title>
+      <title><%= format_integer(@block.duration) %>&micro;s (<%= trunc((@block.duration * 100) / @top_block.duration) %>%) <%=@block.function %></title>
     </svg>
     """
   end
@@ -72,5 +72,14 @@ defmodule FlameOn.SVG do
     else
       str
     end
+  end
+
+  defp format_integer(integer) do
+    integer
+    |> Integer.to_charlist()
+    |> Enum.reverse()
+    |> Enum.chunk_every(3)
+    |> Enum.join(",")
+    |> String.reverse()
   end
 end


### PR DESCRIPTION
Improve readability in the microsecond numbers on tooltips by adding commas.