### PR TITLE
Increase max arity of traced functions from 4 to 254

### DIFF
--- a/lib/flame_on/capture/mock_function.ex
+++ b/lib/flame_on/capture/mock_function.ex
@@ -12,58 +12,18 @@ defmodule FlameOn.Capture.MockFunction do
     already_started?
   end
 
-  def generate(_module, _function, 0) do
-    pid = self()
+  for n <- 0..26 do
+    args = Enum.take(~w(a b c d e f g h i j k l m n o p q r s t u v w x y z)a, n)
 
-    fn ->
-      already_started? = start_if_not_started(pid)
-      result = :meck.passthrough([])
-      if !already_started?, do: Trace.stop_trace()
-      result
-    end
-  end
+    def generate(_module, _function, unquote(n)) do
+      pid = self()
 
-  def generate(_module, _function, 1) do
-    pid = self()
-
-    fn a ->
-      already_started? = start_if_not_started(pid)
-      result = :meck.passthrough([a])
-      if !already_started?, do: Trace.stop_trace()
-      result
-    end
-  end
-
-  def generate(_module, _function, 2) do
-    pid = self()
-
-    fn a, b ->
-      already_started? = start_if_not_started(pid)
-      result = :meck.passthrough([a, b])
-      if !already_started?, do: Trace.stop_trace()
-      result
-    end
-  end
-
-  def generate(_module, _function, 3) do
-    pid = self()
-
-    fn a, b, c ->
-      already_started? = start_if_not_started(pid)
-      result = :meck.passthrough([a, b, c])
-      if !already_started?, do: Trace.stop_trace()
-      result
-    end
-  end
-
-  def generate(_module, _function, 4) do
-    pid = self()
-
-    fn a, b, c, d ->
-      already_started? = start_if_not_started(pid)
-      result = :meck.passthrough([a, b, c, d])
-      if !already_started?, do: Trace.stop_trace()
-      result
+      fn unquote_splicing(Enum.map(args, &Macro.var(&1, __MODULE__))) ->
+        already_started? = start_if_not_started(pid)
+        result = :meck.passthrough(unquote(Enum.map(args, &Macro.var(&1, __MODULE__))))
+        if !already_started?, do: Trace.stop_trace()
+        result
+      end
     end
   end
 end

--- a/lib/flame_on/capture/mock_function.ex
+++ b/lib/flame_on/capture/mock_function.ex
@@ -12,8 +12,10 @@ defmodule FlameOn.Capture.MockFunction do
     already_started?
   end
 
-  for n <- 0..26 do
-    args = Enum.take(~w(a b c d e f g h i j k l m n o p q r s t u v w x y z)a, n)
+  arg_names = Enum.map(1..254, &:"arg#{&1}")
+
+  for n <- 0..254 do
+    args = Enum.take(arg_names, n)
 
     def generate(_module, _function, unquote(n)) do
       pid = self()


### PR DESCRIPTION
Through the power of ✨macros✨, this PR adds support for tracing functions up to 254-arity by defining the `generate/3` clauses in a list comprehension.

I couldn't get up to the full 255 – I think due to Meck adding an extra arg in there somewhere.

@TheFirstAvenger This was the root cause of the issue we were seeing today: I was trying to trace a 5-arity function.