### PR TITLE
Improve performance when navigating flame graph

### DIFF
--- a/lib/flame_on/component.ex
+++ b/lib/flame_on/component.ex
@@ -4,6 +4,7 @@ defmodule FlameOn.Component do
 
   import Ecto.Changeset
   import FlameOn.ErrorHelpers
+  import FlameOn.Format
 
   alias FlameOn.Capture.Block
   alias FlameOn.Capture.Config

--- a/lib/flame_on/component.html.heex
+++ b/lib/flame_on/component.html.heex
@@ -1,4 +1,10 @@
 <div style="display: flex; flex-direction: column; align-items: center;">
+  <script>
+    window.addEventListener('phx:flame-on-svg', function(event) {
+      // This element is in FlameOn.SVG
+      document.getElementById('flame-on-svg-root').innerHTML = event.detail.svg;
+    });
+  </script>
   <style>
     .flame-on-form {
       display: grid;

--- a/lib/flame_on/component.html.heex
+++ b/lib/flame_on/component.html.heex
@@ -139,6 +139,6 @@
       <a href="#" phx-click="view_block" phx-target={@myself} phx-value-id={block.id} style="font-size: 12.5px; font-family: monospace"><%= FlameOn.SVG.mfa_to_string(block.function) %> </a>
       <% end %>
     <% end %>
-    <.live_component module={FlameOn.SVG} block={@viewing_block} parent={@myself} socket={@socket} id="svg_results" />
+    <.live_component module={FlameOn.SVG} block={@viewing_block} parent={@myself} id="svg_results" />
   <% end %>
 </div>

--- a/lib/flame_on/component.html.heex
+++ b/lib/flame_on/component.html.heex
@@ -136,9 +136,9 @@
   <%= if not is_nil(@viewing_block) do %>
     <%= if @view_block_path do %>
       <%= for %Block{} = block <- @view_block_path do %>
-      <a href="#" phx-click="view_block" phx-target={@myself} phx-value-id={block.id} style="font-size: 12.5px; font-family: monospace"><%= FlameOn.SVG.mfa_to_string(block.function) %> </a>
+      <a href="#" phx-click="view_block" phx-target={@myself} phx-value-id={block.id} style="font-size: 12.5px; font-family: monospace"><%= mfa_to_string(block.function) %> </a>
       <% end %>
     <% end %>
-    <.live_component module={FlameOn.SVG} block={@viewing_block} parent={@myself} id="svg_results" />
+    <.live_component module={FlameOn.SVG} root_block={@root_block} viewing_block={@viewing_block} parent={@myself} id="svg_results" />
   <% end %>
 </div>

--- a/lib/flame_on/format.ex
+++ b/lib/flame_on/format.ex
@@ -1,0 +1,19 @@
+defmodule FlameOn.Format do
+  @moduledoc """
+  Utility functions for converting data to display as a string.
+  """
+
+  def mfa_to_string({m, f, a}) do
+    m =
+      case "#{m}" do
+        "Elixir." <> rest -> rest
+        other -> other
+      end
+
+    "#{m}.#{f}/#{a}"
+  end
+
+  def mfa_to_string(mfa) do
+    inspect(mfa)
+  end
+end

--- a/lib/flame_on/svg.ex
+++ b/lib/flame_on/svg.ex
@@ -1,40 +1,72 @@
 defmodule FlameOn.SVG do
   use Phoenix.LiveComponent
+
+  import FlameOn.Format
+
   alias FlameOn.Capture.Block
 
+  def mount(socket) do
+    socket = assign(socket, :block_height, 25)
+    {:ok, socket}
+  end
+
   def render(assigns) do
-    %Block{} = top_block = Map.fetch!(assigns, :block)
-
-    assigns =
-      assigns
-      |> assign(:blocks, List.flatten(flatten(top_block)))
-      |> assign(:duration_ratio, 1276 / top_block.duration)
-      |> assign(:block_height, 25)
-      |> assign(:top_block, top_block)
-
     ~H"""
-    <svg width="1276" height={@block_height * top_block.max_child_level} style="background-color: white;">
-    <style>
-      svg > svg {
-        cursor: pointer;
-      }
+    <div style={"overflow: hidden; position: relative; width: 1276px; height: #{@block_height * @root_block.max_child_level}px"}>
+      <svg style={"background-color: white; position: absolute; #{svg_zoom_style(@root_block, @viewing_block, @block_height)}"}>
+        <style>
+          svg > svg {
+            cursor: pointer;
+          }
 
-      svg > svg > rect {
-        stroke: white;
-        rx: 5px;
-      }
+          svg > svg > rect {
+            stroke: white;
+            rx: 5px;
+          }
 
-      svg > svg > text {
-        font-size: <%= @block_height / 2 %>px;
-        font-family: monospace;
-        dominant-baseline: middle;
-      }
-    </style>
-      <%= for block <- @blocks do %>
-        <%= render_flame_on_block(%{block: block, block_height: @block_height, duration_ratio: @duration_ratio, top_block: @top_block, parent: @parent}) %>
-      <% end %>
-    </svg>
+          svg > svg > text {
+            font-size: <%= @block_height / 2 %>px;
+            font-family: monospace;
+            dominant-baseline: middle;
+          }
+        </style>
+
+        <%= for block <- flattened_blocks(@root_block) do %>
+          <%= render_flame_on_block(%{block: block, block_height: @block_height, top_block: @root_block, parent: @parent}) %>
+        <% end %>
+      </svg>
+    </div>
     """
+  end
+
+  defp svg_zoom_style(root_block, viewing_block, block_height) do
+    # The x-scaling factor is >= 1.0; it represents how many times shorter the viewing_block
+    # is compared to the root_block
+    x_scale = root_block.duration / viewing_block.duration
+
+    # Scale the SVG to the width of the viewing_block
+    width = pct(x_scale)
+
+    # The height is always 100%
+    height = pct(1)
+
+    # Move the left edge of the SVG outside the canvas based on its start time and the scaling factor,
+    # then turn that into a percentage based on the full capture duration
+    left = pct(-1 * x_scale * (viewing_block.absolute_start - root_block.absolute_start), root_block.duration)
+
+    # Move the top edge of the SVG outside the canvas based on the row height and number of levels
+    top = "#{-block_height * (viewing_block.level - 1)}px"
+
+    "width: #{width}; height: #{height}; top: #{top}; left: #{left}"
+  end
+
+
+  defp flattened_blocks(top_block) do
+    List.flatten(flatten(top_block))
+  end
+
+  defp flatten(%Block{children: children} = block) do
+    [block | Enum.map(children, &flatten/1)]
   end
 
   defp render_flame_on_block(%{block: %Block{function: nil}}), do: ""
@@ -43,16 +75,12 @@ defmodule FlameOn.SVG do
     color = color_for_function(assigns.block.function)
 
     ~H"""
-    <svg width={Enum.max([trunc(@block.duration * @duration_ratio), 1])} height={@block_height} x={(@block.absolute_start - @top_block.absolute_start) * @duration_ratio} y={(@block.level - @top_block.level) * @block_height} phx-click="view_block" phx-target={@parent} phx-value-id={@block.id}>
+    <svg width={pct(@block.duration, @top_block.duration)} height={@block_height} x={pct(@block.absolute_start - @top_block.absolute_start, @top_block.duration)} y={(@block.level - @top_block.level) * @block_height} phx-click="view_block" phx-target={@parent} phx-value-id={@block.id}>
       <rect width="100%" height="100%" style={"fill: #{color};"}></rect>
       <text x={@block_height/4} y={@block_height * 0.5}><%= mfa_to_string(@block.function) %></text>
       <title><%= format_integer(@block.duration) %>&micro;s (<%= trunc((@block.duration * 100) / @top_block.duration) %>%) <%= mfa_to_string(@block.function) %></title>
     </svg>
     """
-  end
-
-  defp flatten(%Block{children: children} = block) do
-    [block | Enum.map(children, &flatten/1)]
   end
 
   defp color_for_function({module, _, _}) do
@@ -94,17 +122,7 @@ defmodule FlameOn.SVG do
     |> String.reverse()
   end
 
-  def mfa_to_string({m, f, a}) do
-    m =
-      case "#{m}" do
-        "Elixir." <> rest -> rest
-        other -> other
-      end
-
-    "#{m}.#{f}/#{a}"
-  end
-
-  def mfa_to_string(mfa) do
-    inspect(mfa)
+  defp pct(numerator, denominator \\ 1) do
+    "#{numerator / denominator * 100}%"
   end
 end

--- a/lib/flame_on/svg.ex
+++ b/lib/flame_on/svg.ex
@@ -31,7 +31,7 @@ defmodule FlameOn.SVG do
       }
     </style>
       <%= for block <- @blocks do %>
-        <%= render_flame_on_block(%{block: block, block_height: @block_height, duration_ratio: @duration_ratio, top_block: @top_block, parent: @parent, socket: @socket}) %>
+        <%= render_flame_on_block(%{block: block, block_height: @block_height, duration_ratio: @duration_ratio, top_block: @top_block, parent: @parent}) %>
       <% end %>
     </svg>
     """

--- a/lib/flame_on/svg.ex
+++ b/lib/flame_on/svg.ex
@@ -32,7 +32,12 @@ defmodule FlameOn.SVG do
         </style>
 
         <%= for block <- flattened_blocks(@root_block) do %>
-          <%= render_flame_on_block(%{block: block, block_height: @block_height, top_block: @root_block, parent: @parent}) %>
+          <.flame_on_block
+            block={block}
+            block_height={@block_height}
+            top_block={@root_block}
+            parent={@parent}
+          />
         <% end %>
       </svg>
     </div>
@@ -69,14 +74,12 @@ defmodule FlameOn.SVG do
     [block | Enum.map(children, &flatten/1)]
   end
 
-  defp render_flame_on_block(%{block: %Block{function: nil}}), do: ""
+  defp flame_on_block(%{block: %Block{function: nil}} = assigns), do: ~H""
 
-  defp render_flame_on_block(assigns) do
-    color = color_for_function(assigns.block.function)
-
+  defp flame_on_block(assigns) do
     ~H"""
     <svg width={pct(@block.duration, @top_block.duration)} height={@block_height} x={pct(@block.absolute_start - @top_block.absolute_start, @top_block.duration)} y={(@block.level - @top_block.level) * @block_height} phx-click="view_block" phx-target={@parent} phx-value-id={@block.id}>
-      <rect width="100%" height="100%" style={"fill: #{color};"}></rect>
+      <rect width="100%" height="100%" style={"fill: #{color_for_function(@block.function)};"}></rect>
       <text x={@block_height/4} y={@block_height * 0.5}><%= mfa_to_string(@block.function) %></text>
       <title><%= format_integer(@block.duration) %>&micro;s (<%= trunc((@block.duration * 100) / @top_block.duration) %>%) <%= mfa_to_string(@block.function) %></title>
     </svg>


### PR DESCRIPTION
Previously, when changing the `@viewing_block`, the entire flame graph below it would re-render, causing socket diffs on the order of several megabytes for each event.

Now, the entire flame graph SVG is rendered once (always with the root block as the "top" block), and it's absolutely positioned within a div container with relative positioning. That way, the SVG can be panned and zoomed to the top block when it is clicked, and the socket diff only contains tiny updates to the SVG styling to position it to the desired top block.

UPDATE: I unlocked a big performance boost by changing the root SVG element to have `phx-update="ignore"`, and instead pushing the SVG down to the page via `push_event` and a JS hook. This prevents morphdom (or whatever) from trying to crawl the DOM, and therefore makes the page updates _much_ snappier as you click around the graph.