### PR TITLE
Don't render blocks shorter than 0.1% of the top block

### DIFF
--- a/lib/flame_on/svg.ex
+++ b/lib/flame_on/svg.ex
@@ -13,7 +13,7 @@ defmodule FlameOn.SVG do
       |> assign(:top_block, top_block)
 
     ~H"""
-    <svg width="1276" height={@block_height * top_block.max_child_level} style="background-color: white;">
+    <svg width="1276" height={@block_height * @top_block.max_child_level} style="background-color: white;">
     <style>
       svg > svg {
         cursor: pointer;

--- a/lib/flame_on/svg.ex
+++ b/lib/flame_on/svg.ex
@@ -40,14 +40,16 @@ defmodule FlameOn.SVG do
   defp render_flame_on_block(%{block: %Block{function: nil}}), do: ""
 
   defp render_flame_on_block(assigns) do
-    color = color_for_function(assigns.block.function)
-
+    # Don't bother rendering a block if it's shorter than 0.1% of the top block duration,
+    # since we won't even be able to see it
     ~H"""
-    <svg width={Enum.max([trunc(@block.duration * @duration_ratio), 1])} height={@block_height} x={(@block.absolute_start - @top_block.absolute_start) * @duration_ratio} y={(@block.level - @top_block.level) * @block_height} phx-click="view_block" phx-target={@parent} phx-value-id={@block.id}>
-      <rect width="100%" height="100%" style={"fill: #{color};"}></rect>
-      <text x={@block_height/4} y={@block_height * 0.5}><%= mfa_to_string(@block.function) %></text>
-      <title><%= format_integer(@block.duration) %>&micro;s (<%= trunc((@block.duration * 100) / @top_block.duration) %>%) <%= mfa_to_string(@block.function) %></title>
-    </svg>
+    <%= if @block.duration / @top_block.duration > 0.001 do %>
+      <svg width={Enum.max([trunc(@block.duration * @duration_ratio), 1])} height={@block_height} x={(@block.absolute_start - @top_block.absolute_start) * @duration_ratio} y={(@block.level - @top_block.level) * @block_height} phx-click="view_block" phx-target={@parent} phx-value-id={@block.id}>
+        <rect width="100%" height="100%" style={"fill: #{color_for_function(@block.function)};"}></rect>
+        <text x={@block_height/4} y={@block_height * 0.5}><%= mfa_to_string(@block.function) %></text>
+        <title><%= format_integer(@block.duration) %>&micro;s (<%= trunc((@block.duration * 100) / @top_block.duration) %>%) <%= mfa_to_string(@block.function) %></title>
+      </svg>
+    <% end %>
     """
   end
 


### PR DESCRIPTION
This PR supplants #16 because it is way simpler and also way more performant. Go figure.

If a block is shorter than 0.1% of the total duration of the top block, then let's not even bother rendering it, since a human can't see it, much less click on it. This has massive savings in both socket bandwidth and HTML rendering time.

Experimentally, after sampling a simple LiveView request with a couple Ecto queries, this cuts down the initial number of SVG elements from 120,000 to 8,000.