### PR TITLE
Fix issue with form validation after running capture

### DIFF
--- a/lib/flame_on/component.ex
+++ b/lib/flame_on/component.ex
@@ -2,78 +2,11 @@ defmodule FlameOn.Component do
   use Phoenix.LiveComponent
   use Phoenix.HTML
 
-  import Ecto.Changeset
   import FlameOn.ErrorHelpers
 
   alias FlameOn.Capture.Block
   alias FlameOn.Capture.Config
-
-  defmodule CaptureSchema do
-    use Ecto.Schema
-    import Ecto.Changeset
-    alias Ecto.Changeset
-
-    schema "capture" do
-      field :module, :string
-      field :function, :string
-      field :arity, :integer
-      field :timeout, :integer
-    end
-
-    @default_attrs %{module: "cowboy_handler", function: "execute", arity: 2, timeout: 15000}
-
-    def changeset(attrs \\ @default_attrs) do
-      %__MODULE__{}
-      |> cast(attrs, [:module, :function, :arity, :timeout])
-      |> validate_required([:module, :function, :arity, :timeout])
-      |> validate_module()
-      |> validate_function_arity()
-    end
-
-    def validate_module(%Changeset{valid?: false} = changeset), do: changeset
-
-    def validate_module(changeset) do
-      module_str = get_field(changeset, :module)
-
-      module =
-        try do
-          String.to_existing_atom(module_str)
-        rescue
-          ArgumentError -> nil
-        end
-
-      if is_nil(module) or (!function_exported?(module, :__info__, 1) and !:erlang.module_loaded(module)) do
-        if String.contains?(module_str, ".") and !String.starts_with?(module_str, "Elixir.") do
-          add_error(changeset, :module, "Elixir modules must start with \"Elixir.\"")
-        else
-          add_error(changeset, :module, "Module does not exist")
-        end
-      else
-        changeset
-      end
-    end
-
-    def validate_function_arity(%Changeset{valid?: false} = changeset), do: changeset
-
-    def validate_function_arity(changeset) do
-      module = changeset |> get_field(:module) |> String.to_existing_atom()
-      function_str = get_field(changeset, :function)
-      arity = get_field(changeset, :arity)
-
-      function =
-        try do
-          String.to_existing_atom(function_str)
-        rescue
-          ArgumentError -> nil
-        end
-
-      if is_nil(function) or !function_exported?(module, function, arity) do
-        add_error(changeset, :function, "No #{function_str}/#{arity} function on #{module}")
-      else
-        changeset
-      end
-    end
-  end
+  alias FlameOn.Component.CaptureSchema
 
   def update(%{flame_on_update: root_block}, socket) do
     socket =
@@ -118,7 +51,7 @@ defmodule FlameOn.Component do
   def handle_event("capture_schema", %{"capture_schema" => attrs}, socket) do
     changeset = CaptureSchema.changeset(attrs)
 
-    socket =
+    {socket, changeset} =
       if changeset.valid? do
         config =
           Config.new(
@@ -132,11 +65,15 @@ defmodule FlameOn.Component do
 
         FlameOn.Capture.capture(config)
 
-        socket
-        |> assign(:capturing?, true)
-        |> assign(:capture_timed_out?, false)
+        socket =
+          socket
+          |> assign(:capturing?, true)
+          |> assign(:capture_timed_out?, false)
+
+        {socket, changeset}
       else
-        socket
+        {:error, changeset} = Ecto.Changeset.apply_action(changeset, :insert)
+        {socket, changeset}
       end
 
     socket = assign(socket, :capture_changeset, changeset)

--- a/lib/flame_on/component/capture_schema.ex
+++ b/lib/flame_on/component/capture_schema.ex
@@ -1,0 +1,72 @@
+defmodule FlameOn.Component.CaptureSchema do
+  use Ecto.Schema
+  import Ecto.Changeset
+  alias Ecto.Changeset
+
+  schema "capture" do
+    field :module, :string
+    field :function, :string
+    field :arity, :integer
+    field :timeout, :integer
+  end
+
+  @default_attrs %{module: "cowboy_handler", function: "execute", arity: 2, timeout: 15000}
+
+  def changeset(attrs \\ @default_attrs) do
+    %__MODULE__{}
+    |> cast(attrs, [:module, :function, :arity, :timeout])
+    |> validate_required([:module, :function, :arity, :timeout])
+    |> validate_module()
+    |> validate_function_arity()
+  end
+
+  defp validate_module(%Changeset{valid?: false} = changeset), do: changeset
+
+  defp validate_module(changeset) do
+    module_str = get_field(changeset, :module)
+
+    module =
+      try do
+        String.to_existing_atom(module_str)
+      rescue
+        ArgumentError -> nil
+      end
+
+    if is_nil(module) or
+         not (function_exported?(module, :__info__, 1) or :erlang.check_old_code(module) or
+                :erlang.module_loaded(module)) do
+      if String.contains?(module_str, ".") and !String.starts_with?(module_str, "Elixir.") do
+        add_error(changeset, :module, "Elixir modules must start with \"Elixir.\"")
+      else
+        add_error(changeset, :module, "Module does not exist")
+      end
+    else
+      changeset
+    end
+  end
+
+  defp validate_function_arity(%Changeset{valid?: false} = changeset), do: changeset
+
+  defp validate_function_arity(changeset) do
+    module = changeset |> get_field(:module) |> String.to_existing_atom()
+    function_str = get_field(changeset, :function)
+    arity = get_field(changeset, :arity)
+
+    function =
+      try do
+        String.to_existing_atom(function_str)
+      rescue
+        ArgumentError -> nil
+      end
+
+    if !is_nil(function) and :erlang.check_old_code(module) do
+      Code.ensure_loaded(module)
+    end
+
+    if is_nil(function) or !function_exported?(module, function, arity) do
+      add_error(changeset, :function, "No #{function_str}/#{arity} function on #{module}")
+    else
+      changeset
+    end
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -6,6 +6,7 @@ defmodule FlameOn.MixProject do
       app: :flame_on,
       version: "0.5.2",
       elixir: "~> 1.13",
+      elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       description: description(),
@@ -21,6 +22,9 @@ defmodule FlameOn.MixProject do
       extra_applications: [:logger]
     ]
   end
+
+  defp elixirc_paths(:test), do: ["lib", "test/support"]
+  defp elixirc_paths(_), do: ["lib"]
 
   defp docs() do
     [

--- a/test/flame_on/component/capture_schema_test.exs
+++ b/test/flame_on/component/capture_schema_test.exs
@@ -1,0 +1,81 @@
+defmodule FlameOn.Component.CaptureSchemaTest do
+  use ExUnit.Case
+
+  alias FlameOn.Component.CaptureSchema
+  alias Ecto.Changeset
+
+  setup do
+    Code.ensure_loaded!(FlameOnTest.ExampleModule)
+    :ok
+  end
+
+  describe "Elixir module" do
+    @valid_attrs %{
+      module: "Elixir.FlameOnTest.ExampleModule",
+      function: "foo",
+      arity: 0,
+      timeout: 15_000
+    }
+    test "valid module passes" do
+      assert %Changeset{valid?: true} = CaptureSchema.changeset(@valid_attrs)
+    end
+
+    test "valid module without `Elixir.` fails" do
+      attrs = %{@valid_attrs | module: "FlameOnTest.ExampleModule"}
+
+      assert %Changeset{valid?: false, errors: [module: {"Elixir modules must start with \"Elixir.\"", []}]} =
+               CaptureSchema.changeset(attrs)
+    end
+
+    test "invalid module fails" do
+      attrs = %{@valid_attrs | module: "Elixir.FlameOnTest.IncorrectExampleModule"}
+
+      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} = CaptureSchema.changeset(attrs)
+    end
+
+    test "invalid function fails" do
+      attrs = %{@valid_attrs | function: "foobar"}
+
+      assert %Changeset{
+               valid?: false,
+               errors: [function: {"No foobar/0 function on Elixir.FlameOnTest.ExampleModule", []}]
+             } = CaptureSchema.changeset(attrs)
+    end
+
+    test "old code function passes" do
+      :ok = :meck.new(FlameOnTest.ExampleModule, [:unstick, :passthrough])
+      :ok = :meck.expect(FlameOnTest.ExampleModule, :foo, fn -> :meck.passthrough() end)
+
+      true = :erlang.check_old_code(FlameOnTest.ExampleModule)
+
+      assert %Changeset{valid?: true} = CaptureSchema.changeset(@valid_attrs)
+    end
+  end
+
+  describe "Erlang module" do
+    @valid_attrs %{
+      module: "code",
+      function: "stop",
+      arity: 0,
+      timeout: 15_000
+    }
+    test "valid module passes" do
+      assert %Changeset{valid?: true} = CaptureSchema.changeset(@valid_attrs)
+    end
+
+    test "invalid module fails" do
+      attrs = %{@valid_attrs | module: "no_code"}
+
+      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} = CaptureSchema.changeset(attrs)
+    end
+
+    test "invalid function fails" do
+      attrs = %{@valid_attrs | function: "foobar"}
+
+      assert %Changeset{
+               valid?: false,
+               errors: [function: {"No foobar/0 function on code", []}]
+             } = CaptureSchema.changeset(attrs)
+    end
+  end
+end

--- a/test/flame_on_test.exs
+++ b/test/flame_on_test.exs
@@ -1,4 +1,3 @@
 defmodule FlameOnTest do
   use ExUnit.Case
-  doctest FlameOn
 end

--- a/test/support/example_module.ex
+++ b/test/support/example_module.ex
@@ -1,0 +1,5 @@
+defmodule FlameOnTest.ExampleModule do
+  def foo do
+    :bar
+  end
+end


### PR DESCRIPTION
Module validation would fail after running the first capture because the `:meck` unload left the `:cowboy_handler` module in `old_code` status. This PR updates the logic to handle to this scenario, and adds some tests around the validation logic.