### PR TITLE
Add MFA validation for remote nodes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+-   Run module/function validations on selected node (thanks @schrockwell)
 -   Upgrade LiveView to v0.18
 
 ## 0.5.2

--- a/lib/flame_on/component.ex
+++ b/lib/flame_on/component.ex
@@ -35,7 +35,7 @@ defmodule FlameOn.Component do
         socket
         |> assign(:capturing?, false)
         |> assign(:root_block, nil)
-        |> assign(:capture_changeset, CaptureSchema.changeset())
+        |> assign(:capture_changeset, CaptureSchema.changeset(Node.self()))
         |> assign(:viewing_block, nil)
         |> assign(:view_block_path, [])
         |> assign(:capture_timed_out?, false)
@@ -49,7 +49,7 @@ defmodule FlameOn.Component do
   end
 
   def handle_event("capture_schema", %{"capture_schema" => attrs}, socket) do
-    changeset = CaptureSchema.changeset(attrs)
+    changeset = CaptureSchema.changeset(socket.assigns.target_node, attrs)
 
     {socket, changeset} =
       if changeset.valid? do
@@ -82,8 +82,8 @@ defmodule FlameOn.Component do
 
   def handle_event("validate", %{"capture_schema" => attrs}, socket) do
     changeset =
-      attrs
-      |> CaptureSchema.changeset()
+      socket.assigns.target_node
+      |> CaptureSchema.changeset(attrs)
       |> Map.put(:action, :insert)
 
     {:noreply, assign(socket, :capture_changeset, changeset)}

--- a/lib/flame_on/component/capture_schema.ex
+++ b/lib/flame_on/component/capture_schema.ex
@@ -12,29 +12,25 @@ defmodule FlameOn.Component.CaptureSchema do
 
   @default_attrs %{module: "cowboy_handler", function: "execute", arity: 2, timeout: 15000}
 
-  def changeset(attrs \\ @default_attrs) do
+  def changeset(node, attrs \\ @default_attrs) do
     %__MODULE__{}
     |> cast(attrs, [:module, :function, :arity, :timeout])
     |> validate_required([:module, :function, :arity, :timeout])
-    |> validate_module()
-    |> validate_function_arity()
+    |> validate_module(node)
+    |> validate_function_arity(node)
   end
 
-  defp validate_module(%Changeset{valid?: false} = changeset), do: changeset
+  defp validate_module(%Changeset{valid?: false} = changeset, _node), do: changeset
 
-  defp validate_module(changeset) do
+  defp validate_module(changeset, node) do
     module_str = get_field(changeset, :module)
 
-    module =
-      try do
-        String.to_existing_atom(module_str)
-      rescue
-        ArgumentError -> nil
-      end
+    module = rpc_to_existing_atom(node, module_str)
 
     if is_nil(module) or
-         not (function_exported?(module, :__info__, 1) or :erlang.check_old_code(module) or
-                :erlang.module_loaded(module)) do
+         not (rpc_function_exported?(node, module, :__info__, 1) or
+                rpc_check_old_code(node, module) or
+                rpc_module_loaded(node, module)) do
       if String.contains?(module_str, ".") and !String.starts_with?(module_str, "Elixir.") do
         add_error(changeset, :module, "Elixir modules must start with \"Elixir.\"")
       else
@@ -45,28 +41,42 @@ defmodule FlameOn.Component.CaptureSchema do
     end
   end
 
-  defp validate_function_arity(%Changeset{valid?: false} = changeset), do: changeset
+  defp validate_function_arity(%Changeset{valid?: false} = changeset, _node), do: changeset
 
-  defp validate_function_arity(changeset) do
+  defp validate_function_arity(changeset, node) do
     module = changeset |> get_field(:module) |> String.to_existing_atom()
     function_str = get_field(changeset, :function)
     arity = get_field(changeset, :arity)
 
-    function =
-      try do
-        String.to_existing_atom(function_str)
-      rescue
-        ArgumentError -> nil
-      end
+    function = rpc_to_existing_atom(node, function_str)
 
-    if !is_nil(function) and :erlang.check_old_code(module) do
+    if !is_nil(function) and rpc_check_old_code(node, module) do
       Code.ensure_loaded(module)
     end
 
-    if is_nil(function) or !function_exported?(module, function, arity) do
+    if is_nil(function) or not rpc_function_exported?(node, module, function, arity) do
       add_error(changeset, :function, "No #{function_str}/#{arity} function on #{module}")
     else
       changeset
     end
+  end
+
+  defp rpc_to_existing_atom(node, string) do
+    case :rpc.call(node, String, :to_existing_atom, [string]) do
+      atom when is_atom(atom) -> atom
+      {:badrpc, {:EXIT, {:badarg, _}}} -> nil
+    end
+  end
+
+  defp rpc_function_exported?(node, module, function, arity) do
+    :rpc.call(node, Kernel, :function_exported?, [module, function, arity])
+  end
+
+  defp rpc_check_old_code(node, module) do
+    :rpc.call(node, :erlang, :check_old_code, [module])
+  end
+
+  defp rpc_module_loaded(node, module) do
+    :rpc.call(node, :erlang, :module_loaded, [module])
   end
 end

--- a/test/flame_on/component/capture_schema_test.exs
+++ b/test/flame_on/component/capture_schema_test.exs
@@ -17,20 +17,21 @@ defmodule FlameOn.Component.CaptureSchemaTest do
       timeout: 15_000
     }
     test "valid module passes" do
-      assert %Changeset{valid?: true} = CaptureSchema.changeset(@valid_attrs)
+      assert %Changeset{valid?: true} = CaptureSchema.changeset(Node.self(), @valid_attrs)
     end
 
     test "valid module without `Elixir.` fails" do
       attrs = %{@valid_attrs | module: "FlameOnTest.ExampleModule"}
 
       assert %Changeset{valid?: false, errors: [module: {"Elixir modules must start with \"Elixir.\"", []}]} =
-               CaptureSchema.changeset(attrs)
+               CaptureSchema.changeset(Node.self(), attrs)
     end
 
     test "invalid module fails" do
       attrs = %{@valid_attrs | module: "Elixir.FlameOnTest.IncorrectExampleModule"}
 
-      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} = CaptureSchema.changeset(attrs)
+      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} =
+               CaptureSchema.changeset(Node.self(), attrs)
     end
 
     test "invalid function fails" do
@@ -39,7 +40,7 @@ defmodule FlameOn.Component.CaptureSchemaTest do
       assert %Changeset{
                valid?: false,
                errors: [function: {"No foobar/0 function on Elixir.FlameOnTest.ExampleModule", []}]
-             } = CaptureSchema.changeset(attrs)
+             } = CaptureSchema.changeset(Node.self(), attrs)
     end
 
     test "old code function passes" do
@@ -48,7 +49,7 @@ defmodule FlameOn.Component.CaptureSchemaTest do
 
       true = :erlang.check_old_code(FlameOnTest.ExampleModule)
 
-      assert %Changeset{valid?: true} = CaptureSchema.changeset(@valid_attrs)
+      assert %Changeset{valid?: true} = CaptureSchema.changeset(Node.self(), @valid_attrs)
     end
   end
 
@@ -60,13 +61,14 @@ defmodule FlameOn.Component.CaptureSchemaTest do
       timeout: 15_000
     }
     test "valid module passes" do
-      assert %Changeset{valid?: true} = CaptureSchema.changeset(@valid_attrs)
+      assert %Changeset{valid?: true} = CaptureSchema.changeset(Node.self(), @valid_attrs)
     end
 
     test "invalid module fails" do
       attrs = %{@valid_attrs | module: "no_code"}
 
-      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} = CaptureSchema.changeset(attrs)
+      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} =
+               CaptureSchema.changeset(Node.self(), attrs)
     end
 
     test "invalid function fails" do
@@ -75,7 +77,7 @@ defmodule FlameOn.Component.CaptureSchemaTest do
       assert %Changeset{
                valid?: false,
                errors: [function: {"No foobar/0 function on code", []}]
-             } = CaptureSchema.changeset(attrs)
+             } = CaptureSchema.changeset(Node.self(), attrs)
     end
   end
 end


### PR DESCRIPTION
Add node arguments to CaptureSchema changeset validations, so we can validate MFAs across the cluster.

Fixes #22.

Note that the base branch is `mb-liveview-0-18`.