### PR TITLE
Don't require Elixir. prefix for Elixir modules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+-   Don't require `Elixir.` prefix on Elixir modules
 -   Rework trace_started? to not rely on Trace GenServer
 -   Run module/function validations on selected node (thanks @schrockwell)
 -   Upgrade LiveView to v0.18

--- a/lib/flame_on/component.ex
+++ b/lib/flame_on/component.ex
@@ -55,7 +55,9 @@ defmodule FlameOn.Component do
       if changeset.valid? do
         config =
           Config.new(
-            Ecto.Changeset.fetch_field!(changeset, :module) |> String.to_existing_atom(),
+            Ecto.Changeset.fetch_field!(changeset, :module)
+            |> CaptureSchema.maybe_prepend_elixir()
+            |> String.to_existing_atom(),
             Ecto.Changeset.fetch_field!(changeset, :function) |> String.to_existing_atom(),
             Ecto.Changeset.fetch_field!(changeset, :arity),
             Ecto.Changeset.fetch_field!(changeset, :timeout),

--- a/test/flame_on/component/capture_schema_test.exs
+++ b/test/flame_on/component/capture_schema_test.exs
@@ -11,7 +11,7 @@ defmodule FlameOn.Component.CaptureSchemaTest do
 
   describe "Elixir module" do
     @valid_attrs %{
-      module: "Elixir.FlameOnTest.ExampleModule",
+      module: "FlameOnTest.ExampleModule",
       function: "foo",
       arity: 0,
       timeout: 15_000
@@ -20,17 +20,15 @@ defmodule FlameOn.Component.CaptureSchemaTest do
       assert %Changeset{valid?: true} = CaptureSchema.changeset(Node.self(), @valid_attrs)
     end
 
-    test "valid module without `Elixir.` fails" do
-      attrs = %{@valid_attrs | module: "FlameOnTest.ExampleModule"}
-
-      assert %Changeset{valid?: false, errors: [module: {"Elixir modules must start with \"Elixir.\"", []}]} =
-               CaptureSchema.changeset(Node.self(), attrs)
+    test "valid module starting with 'Elixir.' passes" do
+      attrs = %{@valid_attrs | module: "Elixir." <> @valid_attrs.module}
+      assert %Changeset{valid?: true} = CaptureSchema.changeset(Node.self(), attrs)
     end
 
     test "invalid module fails" do
-      attrs = %{@valid_attrs | module: "Elixir.FlameOnTest.IncorrectExampleModule"}
+      attrs = %{@valid_attrs | module: "FlameOnTest.IncorrectExampleModule"}
 
-      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} =
+      assert %Changeset{valid?: false, errors: [module: {"Module not found", []}]} =
                CaptureSchema.changeset(Node.self(), attrs)
     end
 
@@ -67,7 +65,7 @@ defmodule FlameOn.Component.CaptureSchemaTest do
     test "invalid module fails" do
       attrs = %{@valid_attrs | module: "no_code"}
 
-      assert %Changeset{valid?: false, errors: [module: {"Module does not exist", []}]} =
+      assert %Changeset{valid?: false, errors: [module: {"Module not found", []}]} =
                CaptureSchema.changeset(Node.self(), attrs)
     end
 


### PR DESCRIPTION
@schrockwell had a great suggestion to not require the `Elixir.` prefix on the module being typed in and instead infer that it is an Elixir module and prepend it ourselves. This PR implements that change. Lowercase modules are handled as Erlang modules, modules entered as `Phoenix.LiveView` will have `Elixir.` prepended in the background, and modules entered as `Elixir.Phoenix.LiveView` will be recognized and handled apprpriately.