### PR TITLE
Improve module validation by using `Code.ensure_loaded?`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next
 
+-   Rework module form validation to be more reliable
 -   Don't require `Elixir.` prefix on Elixir modules
 -   Rework trace_started? to not rely on Trace GenServer
 -   Run module/function validations on selected node (thanks @schrockwell)


### PR DESCRIPTION
Swap to using `Code.ensure_loaded?` function to validate module. This swaps the validation from read-only to potentially loading code. After an internal discussion, we feel this is an acceptable as 1) The module being loaded has to already be available to the runtime 2) Flame On shouldn't generally be run in production and 3) Flame On is protected the same as LiveDashboard, so if it is accessible by a bad actor, they have access to other more dangerous stuff.
Fixes #25 