### PR TITLE
Mitigate race condition when under load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - Fix issue with changeset form not honoring initial node
 - Elixir 1.16 in CI
 - Increase formatter line length
+- Mitigate race condition in trace_started? function.
 
 ## 0.6.0
 

--- a/lib/flame_on/capture/server.ex
+++ b/lib/flame_on/capture/server.ex
@@ -23,7 +23,7 @@ defmodule FlameOn.Capture.Server do
   singleton to track that it has started for a given capture
   """
   def trace_started? do
-    case ETS.Set.wrap_existing!(__MODULE__) do
+    case ETS.Set.wrap_existing(__MODULE__) do
       {:ok, set} ->
         {:started?, started?} = ETS.Set.get!(set, :started?, {:started?, false})
         if !started?, do: ETS.Set.put!(set, {:started?, true})


### PR DESCRIPTION
When under high parallel load, multiple requests to check if the trace has already started can get through a race condition and throw an error. The race condition exists because #24 swapped us from a GenServer to an ETS table because the GenServer mailbox was getting overloaded. We now check that condition and don't start a trace (the parallel load state this happens in ensures that a trace will start for at least one of the calls).

Fixes #41.